### PR TITLE
Start using failure::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache 2.0"
 [dependencies]
 num = "0.2.0"
 serde = "1.0.70"
+failure = "0.1.3"
 
 [dev-dependencies]
 serde_derive = "1.0.70"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate failure;
+
 extern crate num;
 extern crate serde;
 

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -1,4 +1,5 @@
 pub use super::Int256;
+use failure::Error;
 use num::bigint::ParseBigIntError;
 use num::traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use num::{BigInt, BigUint};
@@ -36,16 +37,12 @@ impl Zero for Uint256 {
 }
 
 impl FromStr for Uint256 {
-    type Err = String;
+    type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with("0x") {
-            BigUint::from_str_radix(&s[2..], 16)
-                .map(Uint256)
-                .map_err(|e| format!("{:?}", e))
+            Ok(BigUint::from_str_radix(&s[2..], 16).map(Uint256)?)
         } else {
-            BigUint::from_str_radix(&s, 10)
-                .map(Uint256)
-                .map_err(|e| format!("{:?}", e))
+            Ok(BigUint::from_str_radix(&s, 10).map(Uint256)?)
         }
     }
 }


### PR DESCRIPTION
This makes FromStr<Uint256> pass num errors using the proper respective
types; originally needed for error handling in althea_rs::bounty_hunter