### PR TITLE
[WIP] Bring num256 to rust standards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ license-file = "LICENSE"
 num = "0.2"
 serde = "1.0"
 failure = "0.1"
+num-derive = "0.2"
+num-traits = "0.2.6"
+serde_derive = "1.0.80"
 
 [dev-dependencies]
 serde_derive = "1.0.80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ failure = "0.1"
 num-derive = "0.2"
 num-traits = "0.2.6"
 serde_derive = "1.0.80"
+lazy_static = "1.2.0"
 
 [dev-dependencies]
 serde_derive = "1.0.80"
 serde_json = "1.0.33"
-lazy_static = "1.2.0"

--- a/src/int256.rs
+++ b/src/int256.rs
@@ -28,11 +28,17 @@ impl Int256 {
 
 impl Bounded for Int256 {
     fn min_value() -> Self {
+        lazy_static! {
+            static ref MIN_VALUE: BigInt = -pow(BigInt::from(2), 255);
+        }
         // -2**255
-        Int256(pow(BigInt::from(-2), 255))
+        Int256(MIN_VALUE.clone())
     }
     fn max_value() -> Self {
-        Int256(pow(BigInt::from(2), 255) - BigInt::from(1))
+        lazy_static! {
+            static ref MAX_VALUE: BigInt = pow(BigInt::from(2), 255) - BigInt::from(1);
+        }
+        Int256(MAX_VALUE.clone())
     }
 }
 

--- a/src/int256.rs
+++ b/src/int256.rs
@@ -1,12 +1,9 @@
-use num::bigint::{BigInt, ToBigInt};
+use num::bigint::BigInt;
 use num::traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
-use num::traits::Signed;
-use num::ToPrimitive;
 use num::{pow, Bounded};
 use serde;
 use serde::ser::Serialize;
 use serde::{Deserialize, Deserializer, Serializer};
-use std::default::Default;
 use std::fmt;
 use std::ops::{Add, AddAssign, Deref, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::str::FromStr;
@@ -21,8 +18,8 @@ impl Int256 {
     pub fn to_uint256(&self) -> Option<Uint256> {
         self.0
             .to_biguint()
-            .filter(|value| value >= &Uint256::max_value() && value <= &Uint256::min_value())
             .map(Uint256)
+            .filter(|value| *value >= Uint256::max_value() && *value <= Uint256::min_value())
     }
 }
 
@@ -103,7 +100,7 @@ impl<'de> Deserialize<'de> for Int256 {
         let s = String::deserialize(deserializer)?;
 
         BigInt::from_str(&s)
-            .map(|v| Int256(v))
+            .map(Int256)
             .map_err(serde::de::Error::custom)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate failure;
+#[macro_use]
+extern crate num_derive;
 
 extern crate num;
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate failure;
 #[macro_use]
 extern crate num_derive;
+#[macro_use]
+extern crate lazy_static;
 
 extern crate num;
 extern crate serde;

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -1,9 +1,11 @@
 pub use super::Int256;
 use failure::Error;
 use num::bigint::ParseBigIntError;
+use num::bigint::ToBigInt;
 use num::traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use num::BigUint;
 use num::Num;
+use num::{pow, Bounded, Zero};
 use serde;
 use serde::ser::Serialize;
 use serde::{Deserialize, Deserializer, Serializer};
@@ -24,6 +26,23 @@ impl Uint256 {
     }
     pub fn from_str_radix(s: &str, radix: u32) -> Result<Uint256, ParseBigIntError> {
         BigUint::from_str_radix(s, radix).map(Uint256)
+    }
+    /// Converts value to a signed 256 bit integer
+    pub fn to_int256(&self) -> Option<Int256> {
+        self.0
+            .to_bigint()
+            .filter(|value| value.bits() <= 255)
+            .map(Int256)
+    }
+}
+
+impl Bounded for Uint256 {
+    fn min_value() -> Self {
+        // -2**255
+        Uint256::zero()
+    }
+    fn max_value() -> Self {
+        Uint256(pow(BigUint::from(2u32), 256) - BigUint::from(1u32))
     }
 }
 

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -42,7 +42,10 @@ impl Bounded for Uint256 {
         Uint256::zero()
     }
     fn max_value() -> Self {
-        Uint256(pow(BigUint::from(2u32), 256) - BigUint::from(1u32))
+        lazy_static! {
+            static ref MAX_VALUE: BigUint = pow(BigUint::from(2u32), 256) - BigUint::from(1u32);
+        }
+        Uint256(MAX_VALUE.clone())
     }
 }
 

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -268,9 +268,9 @@ fn to_hex() {
 #[test]
 fn into_array() {
     let val = Uint256::from(1024u16);
-    let foo: [u8; 32] = val.into();
+    let data: [u8; 32] = val.into();
     assert_eq!(
-        foo,
+        data,
         [
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 4, 0

--- a/tests/num256_test.rs
+++ b/tests/num256_test.rs
@@ -10,7 +10,7 @@ extern crate serde;
 use num::pow::pow;
 use num::traits::cast::ToPrimitive;
 use num::traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
-use num::{BigInt, BigUint, Bounded, Zero};
+use num::{BigUint, Bounded, Zero};
 use num256::{Int256, Uint256};
 use std::ops::{Add, Div, Sub};
 
@@ -71,7 +71,7 @@ fn test_from_uint() {
 #[should_panic]
 fn test_from_uint_to_int() {
     let uint = BIGGEST_UINT.clone();
-    let res = uint.to_int256().unwrap();
+    let _res = uint.to_int256().unwrap();
 }
 
 #[test]
@@ -380,7 +380,7 @@ fn test_uint_to_int_panic() {
 #[test]
 fn test_int256() {
     assert_eq!(
-        Int256::from(Int256::max_value().clone() + Int256::zero()),
+        Int256::max_value().clone() + Int256::zero(),
         Int256::max_value().clone()
     );
 

--- a/tests/num256_test.rs
+++ b/tests/num256_test.rs
@@ -10,7 +10,7 @@ extern crate serde;
 use num::pow::pow;
 use num::traits::cast::ToPrimitive;
 use num::traits::ops::checked::{CheckedAdd, CheckedMul, CheckedSub};
-use num::BigInt;
+use num::{BigInt, Zero};
 use num256::{Int256, Uint256};
 use std::ops::{Add, Div, Sub};
 
@@ -52,11 +52,11 @@ fn serialize() {
 #[test]
 fn test_from_uint() {
     let (a, b, c, d, e) = (
-        Uint256::from(8 as u8),
-        Uint256::from(8 as u16),
-        Uint256::from(8 as u32),
-        Uint256::from(8 as u64),
-        Uint256::from(8 as usize),
+        Uint256::from(8u8),
+        Uint256::from(8u16),
+        Uint256::from(8u32),
+        Uint256::from(8u64),
+        Uint256::from(8usize),
     );
 
     assert_eq!(a, b);
@@ -84,137 +84,143 @@ fn test_from_int() {
 #[test]
 #[should_panic]
 fn test_uint_add_panic() {
-    let _val = BIGGEST_UINT.clone() + Uint256::from(1 as u32);
+    let _val = BIGGEST_UINT.clone() + Uint256::from(1u32);
 }
 
 #[test]
 fn test_uint_add_no_panic() {
-    let _val = BIGGEST_UINT.clone() + Uint256::from(0 as u32);
+    let _val = BIGGEST_UINT.clone() + Uint256::from(0u32);
 }
 
 #[test]
 #[should_panic]
 fn test_uint_from_add_panic() {
-    let _val = BIGGEST_UINT.clone().add(Uint256::from(1));
+    let _val = BIGGEST_UINT.clone().add(Uint256::from(1u8));
 }
 
 #[test]
 fn test_uint_from_add_no_panic() {
-    let _val = BIGGEST_UINT.clone().add(Uint256::from(0));
+    let _val = BIGGEST_UINT.clone().add(Uint256::zero());
 }
 
 #[test]
 #[should_panic]
 fn test_uint_sub_panic() {
-    let _val = Uint256::from(1 as u32).sub(Uint256::from(2 as u32));
+    let _val = Uint256::from(1u32).sub(Uint256::from(2u32));
 }
 
 #[test]
 fn test_uint_sub_no_panic() {
     assert_eq!(
-        Uint256::from(1 as u32).sub(Uint256::from(1 as u32)),
-        Uint256::from(0 as u32)
+        Uint256::from(1u32).sub(Uint256::from(1u32)),
+        Uint256::from(0u32)
     );
 }
 
 #[test]
 #[should_panic]
 fn test_uint_from_sub_panic() {
-    let _val = Uint256::from(1 as u32).sub(Uint256::from(2));
+    let _val = Uint256::from(1u32).sub(Uint256::from(2u8));
 }
 
 #[test]
 fn test_uint_from_sub_no_panic() {
     assert_eq!(
-        Uint256::from(1 as u32).sub(Uint256::from(1)),
-        Uint256::from(0 as u32)
+        Uint256::from(1u32).sub(Uint256::from(1u8)),
+        Uint256::from(0u32)
     );
 }
 
 #[test]
 #[should_panic]
 fn test_uint_mul_panic() {
-    let _val: Uint256 = BIGGEST_UINT.clone() * Uint256::from(2);
+    let _val: Uint256 = BIGGEST_UINT.clone() * Uint256::from(2u8);
 }
 
 #[test]
 fn test_uint_mul_no_panic() {
-    assert_eq!(Uint256::from(3) * Uint256::from(2), Uint256::from(6));
+    assert_eq!(Uint256::from(3u8) * Uint256::from(2u8), Uint256::from(6u8));
 }
 
 #[test]
 #[should_panic]
 fn test_uint_from_mul_panic() {
-    let _val = BIGGEST_UINT.clone() * Uint256::from(2);
+    let _val = BIGGEST_UINT.clone() * Uint256::from(2u8);
 }
 
 #[test]
 fn test_uint_from_mul_no_panic() {
-    assert_eq!(Uint256::from(3) * Uint256::from(2), Uint256::from(6));
+    assert_eq!(Uint256::from(3u8) * Uint256::from(2u8), Uint256::from(6u8));
 }
 
 #[test]
 #[should_panic]
 fn test_uint_div_panic() {
-    let _val = BIGGEST_UINT.clone() / Uint256::from(0);
+    let _val = BIGGEST_UINT.clone() / Uint256::zero();
 }
 
 #[test]
 fn test_uint_div_no_panic() {
-    assert_eq!(Uint256::from(6) / Uint256::from(2), Uint256::from(3));
+    assert_eq!(Uint256::from(6u8) / Uint256::from(2u8), Uint256::from(3u8));
 }
 
 #[test]
 fn test_uint_from_div_assign_no_panic() {
-    assert_eq!(Uint256::from(6).div(Uint256::from(2)), Uint256::from(3));
+    assert_eq!(
+        Uint256::from(6u8).div(Uint256::from(2u8)),
+        Uint256::from(3u8)
+    );
 }
 
 #[test]
 #[should_panic]
 fn test_uint_from_div_panic() {
-    let _val = BIGGEST_UINT.clone().div(Uint256::from(0));
+    let _val = BIGGEST_UINT.clone().div(Uint256::from(0u8));
 }
 
 #[test]
 fn test_uint_from_div_no_panic() {
-    assert_eq!(Uint256::from(6).div(Uint256::from(2)), Uint256::from(3));
+    assert_eq!(
+        Uint256::from(6u8).div(Uint256::from(2u8)),
+        Uint256::from(3u8)
+    );
 }
 
 #[test]
 fn test_uint256() {
     assert!(
-        BIGGEST_UINT.checked_add(&Uint256::from(1 as u32)).is_none(),
+        BIGGEST_UINT.checked_add(&Uint256::from(1u32)).is_none(),
         "should return None adding 1 to biggest"
     );
 
     assert!(
-        BIGGEST_UINT.checked_add(&Uint256::from(0 as u32)).is_some(),
+        BIGGEST_UINT.checked_add(&Uint256::from(0u32)).is_some(),
         "should return Some adding 0 to biggest"
     );
 
     assert!(
-        &Uint256::from(1 as u32)
-            .checked_sub(&Uint256::from(2 as u32))
+        &Uint256::from(1u32)
+            .checked_sub(&Uint256::from(2u32))
             .is_none(),
         "should return None if RHS is larger than LHS"
     );
 
     assert!(
-        &Uint256::from(1 as u32)
-            .checked_sub(&Uint256::from(1 as u32))
+        &Uint256::from(1u32)
+            .checked_sub(&Uint256::from(1u32))
             .is_some(),
         "should return Some if RHS is not larger than LHS"
     );
 
-    let num = &Uint256::from(1 as u32)
-        .checked_sub(&Uint256::from(1 as u32))
+    let num = &Uint256::from(1u32)
+        .checked_sub(&Uint256::from(1u32))
         .unwrap()
         .to_u32()
         .unwrap();
     assert_eq!(*num, 0, "1 - 1 should = 0");
 
-    let num2 = &Uint256::from(346 as u32)
-        .checked_sub(&Uint256::from(23 as u32))
+    let num2 = &Uint256::from(346u32)
+        .checked_sub(&Uint256::from(23u32))
         .unwrap()
         .to_u32()
         .unwrap();
@@ -313,13 +319,13 @@ fn test_int_from_div_no_panic() {
 #[test]
 #[should_panic]
 fn test_uint_to_int_panic() {
-    Int256::from(BIGGEST_INT_AS_UINT.clone().add(Uint256::from(1 as u32)));
+    Int256::from(BIGGEST_INT_AS_UINT.clone().add(Uint256::from(1u32)));
 }
 
 #[test]
 fn test_int256() {
     assert_eq!(
-        Int256::from(BIGGEST_INT_AS_UINT.clone().add(Uint256::from(0 as u32))),
+        Int256::from(BIGGEST_INT_AS_UINT.clone().add(Uint256::from(0u32))),
         BIGGEST_INT.clone()
     );
 
@@ -360,7 +366,7 @@ fn test_increment_2_to_the_power_of_255() {
         .parse()
         .unwrap();
     assert_eq!(value.bits(), 255);
-    value += 1;
+    value += 1u8;
     assert_eq!(value.bits(), 256);
 }
 
@@ -371,7 +377,7 @@ fn test_increment_2_to_the_power_of_256() {
         .parse()
         .unwrap();
     assert_eq!(value.bits(), 256);
-    value += 1;
+    value += 1u8;
     assert_eq!(value.bits(), 256);
 }
 
@@ -387,7 +393,7 @@ fn test_increment_2_to_the_power_of_256_checked() {
 
 #[test]
 fn test_uint_underflow() {
-    let value: Uint256 = 0.into();
+    let value: Uint256 = Uint256::zero();
     let res = value.checked_sub(&Uint256::from(1u32));
     assert!(res.is_none());
 }
@@ -395,6 +401,6 @@ fn test_uint_underflow() {
 #[test]
 #[should_panic]
 fn test_uint_underflow_assign() {
-    let mut value: Uint256 = 0.into();
-    value -= 1;
+    let mut value: Uint256 = Uint256::zero();
+    value -= 1u8;
 }


### PR DESCRIPTION
This removes unsafe conversions that aren't supposed to happen safely.
Instead, a checked version of such conversions are provided thanks to
ToPrimitive/FromPrimitive. This will give less chance to shoot ourselves
in the foot.

This brings us closer to the goal of rust numerical standards.

# Todo

- [x] Less unsafe implicit conversions that are not happening in Rust's stdlib (i.e. only way to do that is through checked conversion).
- [x] Reuse more standard traits for numbers and arithmetic.

Closes #3 